### PR TITLE
#38 fixed trello issues

### DIFF
--- a/src/assets/chains/thetaLogo.svg
+++ b/src/assets/chains/thetaLogo.svg
@@ -1,1 +1,18 @@
-<svg data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 433 433" ><defs><linearGradient id="a" x1="112.27" y1="112.27" x2="320.73" y2="320.73" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#2ab8e6"/><stop offset=".53" stop-color="#29cad2"/><stop offset="1" stop-color="#2ee4be"/></linearGradient><linearGradient id="b" x1="175.55" y1="175.91" x2="258.18" y2="258.54" xlink:href="#a"/></defs><title>theta</title><path fill="#1b1f2b" d="M0 0h433v433H0z"/><path fill="#1b1f2b" stroke-linejoin="bevel" stroke-width="27.222" stroke="url(#a)" d="M145.06 93.1h142.89v246.81H145.06z"/><path d="M259.8 255.47h-29.59v31h-26.7v-31h-29.59v-26.7h85.88zm0-76.5h-29.59v-31h-26.7v31h-29.59v26.7h85.88z" fill="url(#b)"/></svg>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 500 500" style="enable-background:new 0 0 500 500;" xml:space="preserve">
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="250.996" y1="3" x2="250.996" y2="497.0496">
+	<stop  offset="0" style="stop-color:#2CB6EC"/>
+	<stop  offset="1" style="stop-color:#27E6BC"/>
+</linearGradient>
+<path style="fill:url(#SVGID_1_);" d="M122.755,495.078c-8.166-8.122-16.383-16.294-24.541-24.408c0-147.688,0-295.04,0-441.835
+	C106.67,20.28,114.817,12.039,123.751,3c84.371,0,169.896,0,255.14,0c8.471,8.168,16.81,16.209,24.888,23.998
+	c0,148.096,0,295.447,0,442.929c-8.365,7.919-16.784,15.888-26.57,25.153C294.084,495.078,208.535,495.078,122.755,495.078z
+	 M354.01,445.354c0-131.114,0-261.314,0-391.891c-69.359,0-137.664,0-206.064,0c0,131.414,0,261.312,0,391.891
+	C216.694,445.354,284.785,445.354,354.01,445.354z M226.934,129.587c0,16.888,0,32.632,0,49.494c-17.504,0-33.703,0-50.402,0
+	c0,17.277,0,33.393,0,50.208c50.078,0,99.418,0,148.962,0c0-17.127,0-33.228,0-50.75c-17.056,0-33.195,0-49.989,0
+	c0-16.872,0-32.311,0-48.953C258.71,129.587,243.477,129.587,226.934,129.587z M275.294,321.027c18.267,0,34.414,0,50.4,0
+	c0-16.768,0-32.136,0-48.112c-49.929,0-99.283,0-149.152,0c0,16.316,0,31.991,0,49.422c17.209,0,33.715,0,51.471,0
+	c0,17.898,0,34.047,0,50.553c15.942,0,30.533,0,47.281,0C275.294,356.043,275.294,339.182,275.294,321.027z"/>
+</svg>

--- a/src/pages/collections/collection.jsx
+++ b/src/pages/collections/collection.jsx
@@ -12,6 +12,7 @@ import CarouselCollection from "../../components/CarouselCollection";
 import Searchbox from "../../components/searchbox";
 import { getCollections } from "../../redux/thunk/getAllCollections";
 import { styled } from "@mui/system";
+import { PopularCollections } from "../analytics/popular-collections";
 
 const CollectionsPage = () => {
   const dispatch = useDispatch();
@@ -112,7 +113,8 @@ const CollectionsPage = () => {
   return (
     <Box>
       <CarouselCollection />
-      <RowSlider title="Popular Collections" />
+      {/* <RowSlider title="Popular Collections" /> */}
+      <PopularCollections title="Popular Collections" />
       <Container>
         <Box
           sx={{

--- a/src/pages/collections/components/nft-card.jsx
+++ b/src/pages/collections/components/nft-card.jsx
@@ -85,7 +85,7 @@ export const NFTCard = ({ view, nft, isSwiper }) => {
                 objectFit: "cover",
                 width: "100%",
                 aspectRatio: "1/1",
-                backgroundImage: `url(${brokenImage})`,
+                // backgroundImage: `url(${brokenImage})`,
               }}
             >
               <img

--- a/src/pages/market/compoents/nft-market-card.jsx
+++ b/src/pages/market/compoents/nft-market-card.jsx
@@ -11,6 +11,8 @@ import flameLogo from "../../../assets/flame.svg";
 import { useDispatch } from "react-redux";
 import { getMarketNFTDetail } from "../../../redux/thunk/getNftDetail";
 import { formatEther, parseEther } from "@ethersproject/units";
+import ThetaLogo from "../../../assets/chains/thetaLogo.svg";
+import KavaLogo from "../../../assets/chains/kavaLogo.svg";
 
 export const NFTMarketCard = ({ view, marketItem }) => {
   const [imgUrl, setImgUrl] = useState();
@@ -54,9 +56,8 @@ export const NFTMarketCard = ({ view, marketItem }) => {
       whiteSpace: "nowrap",
     },
     network: {
-      fontSize: ".625em",
-      fontWeight: "400",
-      color: "#6C6C6C",
+      width: "24px",
+      height: "24px",
     },
   };
 
@@ -127,16 +128,21 @@ export const NFTMarketCard = ({ view, marketItem }) => {
                   </Typography>
                   <img src={verifiedLogo} alt="verified" />
                 </Box>
-                <Typography
+                <img
+                  style={styles.network}
+                  src={marketItem.network === "kava" ? KavaLogo : ThetaLogo}
+                  alt="network"
+                />
+                {/* <Typography
                   sx={styles.network}
-                >{`#${marketItem.Network}`}</Typography>
-                <Box style={styles.meta}>
+                >{`#${marketItem.Network}`}</Typography> */}
+                {/* <Box style={styles.meta}>
                   <Typography>#{marketItem.TokenId}</Typography>
                   <Box style={styles.meta}>
                     <img src={flameLogo} alt="flame" />
                     <Typography>{marketItem.Price}</Typography>
                   </Box>
-                </Box>
+                </Box> */}
               </Box>
             )}
           </Box>


### PR DESCRIPTION
- Market tab still shows NFT's chain as #theta or #kava instead of logo as well as token ID
- Updated Theta logo on nft cards
- When an NFT image doesn't fill up the NFT card, the back ground need to be the same color as the card itself (as in no background)
- Popular collections on the "Collections" page should be exactly the same as the ones that are on the home page