### PR TITLE
issue #66 Missing "List to Sell", "List to Swap", "Send NFT" buttons for NFTs that are owned by a wallet

### DIFF
--- a/src/pages/NFTMillion/Spots.jsx
+++ b/src/pages/NFTMillion/Spots.jsx
@@ -88,7 +88,6 @@ export default React.memo(function Spots(props) {
         }
 
         let src = e.image;
-        console.log("e._index: ", e._index);
         if (editIndex === e._index) {
           src = editImageUrl;
         } else {

--- a/src/pages/market/compoents/nft-market-card.jsx
+++ b/src/pages/market/compoents/nft-market-card.jsx
@@ -60,6 +60,13 @@ export const NFTMarketCard = ({ view, marketItem }) => {
       width: "24px",
       height: "24px",
     },
+    price: {
+      display: "flex",
+      flexDirection: "row",
+      justifyContent: "space-between",
+      gap: ".5rem",
+      marginTop: ".5rem",
+    },
   };
 
   // const truncate = (text, maxLength) => {
@@ -87,7 +94,9 @@ export const NFTMarketCard = ({ view, marketItem }) => {
           const newUrl = url.replace("ipfs://", "https://ipfs.io/ipfs/");
           setImgUrl(`https://wsrv.nl/?url=${newUrl}&w=200&h=200&fit=outside`);
         } else {
-          setImgUrl(`https://wsrv.nl/?url=${marketItem.nftDetails.metadata.image}&w=200&h=200&fit=outside`);
+          setImgUrl(
+            `https://wsrv.nl/?url=${marketItem.nftDetails.metadata.image}&w=200&h=200&fit=outside`
+          );
         }
       } catch {
         setImgUrl(broken);
@@ -129,21 +138,25 @@ export const NFTMarketCard = ({ view, marketItem }) => {
                   </Typography>
                   <img src={verifiedLogo} alt="verified" />
                 </Box>
-                <img
+                {/* <img
                   style={styles.network}
                   src={marketItem.network === "kava" ? KavaLogo : ThetaLogo}
                   alt="network"
-                />
+                /> */}
                 {/* <Typography
                   sx={styles.network}
                 >{`#${marketItem.Network}`}</Typography> */}
-                {/* <Box style={styles.meta}>
-                  <Typography>#{marketItem.TokenId}</Typography>
+                <Box style={styles.price}>
+                  <img
+                    style={styles.network}
+                    src={marketItem.network === "kava" ? KavaLogo : ThetaLogo}
+                    alt="network"
+                  />
                   <Box style={styles.meta}>
                     <img src={flameLogo} alt="flame" />
                     <Typography>{marketItem.Price}</Typography>
                   </Box>
-                </Box> */}
+                </Box>
               </Box>
             )}
           </Box>

--- a/src/pages/view-nft/NFTView.jsx
+++ b/src/pages/view-nft/NFTView.jsx
@@ -146,6 +146,18 @@ export const NFTView = () => {
     }
   }, [listings, address, tokenId]);
 
+  useEffect(() => {
+    if (marketItems.length > 0) {
+      const index = marketItems.findIndex(
+        (obj) =>
+          obj.TokenId === Number(tokenId) &&
+          obj.NFTContractAddress === address &&
+          obj.Network === network
+      );
+      setMarket(marketItems[index]);
+    }
+  }, [network, marketItems]);
+
   const handleOfferSwap = () => {
     if (account) {
       setOfferDlgOpen(true);
@@ -290,20 +302,6 @@ export const NFTView = () => {
     forceUpdate();
   };
 
-  useEffect(() => {
-    if (marketItems.length > 0) {
-      const index = marketItems.findIndex(
-        (obj) =>
-          obj.TokenId === Number(tokenId) &&
-          obj.NFTContractAddress === address &&
-          obj.Network === network
-      );
-      setMarket(marketItems[index]);
-    }
-  }, [marketItems]);
-
-  // console.log("metadata", metadata, address, tokenId, network);
-
   return (
     <Fragment>
       <Container>
@@ -315,45 +313,52 @@ export const NFTView = () => {
             name={collectionName}
           />
           <NFTCardActionContaniner>
-            {!loading && account && account === owner && !isListed && (
-              <Box sx={styles.row}>
-                <Button
-                  sx={styles.orangeButton}
-                  variant="contained"
-                  onClick={() => setListDlgOpen(true)}
-                >
-                  Swap
-                </Button>
-                <Button
-                  sx={styles.orangeButton}
-                  variant="contained"
-                  onClick={() => setSendOpen(true)}
-                >
-                  Send
-                </Button>
-                <Button
-                  sx={styles.orangeButton}
-                  variant="contained"
-                  onClick={() => setSellOpen(true)}
-                >
-                  Sell
-                </Button>
-              </Box>
-            )}
-            {!loading && account && account === owner && isListed && (
-              <>
-                <Button
-                  sx={styles.orangeButton}
-                  color="error"
-                  variant="contained"
-                  onClick={handleRemoveNFT}
-                >
-                  Remove Listing
-                </Button>
-              </>
-            )}
+            {!loading &&
+              account &&
+              account.toLowerCase() === owner.toLowerCase() &&
+              !isListed && (
+                <Box sx={styles.row}>
+                  <Button
+                    sx={styles.orangeButton}
+                    variant="contained"
+                    onClick={() => setListDlgOpen(true)}
+                  >
+                    LIST TO SWAP
+                  </Button>
+                  <Button
+                    sx={styles.orangeButton}
+                    variant="contained"
+                    onClick={() => setSellOpen(true)}
+                  >
+                    LIST TO SELL
+                  </Button>
+                  <Button
+                    sx={styles.orangeButton}
+                    variant="contained"
+                    onClick={() => setSendOpen(true)}
+                  >
+                    SEND NFT
+                  </Button>
+                </Box>
+              )}
+            {!loading &&
+              account &&
+              account.toLowerCase() === owner.toLowerCase() &&
+              isListed && (
+                <>
+                  <Button
+                    sx={styles.orangeButton}
+                    color="error"
+                    variant="contained"
+                    onClick={handleRemoveNFT}
+                  >
+                    Remove Listing
+                  </Button>
+                </>
+              )}
             {!loading &&
               market &&
+              account &&
               market.SellerAddress &&
               account.toUpperCase() === market.SellerAddress.toUpperCase() &&
               market.IsSold === false &&
@@ -378,6 +383,7 @@ export const NFTView = () => {
               )}
             {!loading &&
               market &&
+              account &&
               market.SellerAddress &&
               account.toUpperCase() !== market.SellerAddress.toUpperCase() &&
               market.IsSold === false &&
@@ -392,19 +398,22 @@ export const NFTView = () => {
                   </Button>
                 </Box>
               )}
-            {!loading && account !== owner && isListed && (
-              <Box sx={styles.row}>
-                <Button
-                  sx={styles.orangeButton}
-                  variant="contained"
-                  onClick={handleOfferSwap}
-                >
-                  Offer SWAP
-                </Button>
-              </Box>
-            )}
+            {!loading &&
+              account &&
+              account.toLowerCase() !== owner.toLowerCase() &&
+              isListed && (
+                <Box sx={styles.row}>
+                  <Button
+                    sx={styles.orangeButton}
+                    variant="contained"
+                    onClick={handleOfferSwap}
+                  >
+                    Offer SWAP
+                  </Button>
+                </Box>
+              )}
             {market && market.Price && (
-              <Typography variant="h6" sx={{ mt: 2, mb: 2 }}>
+              <Typography variant="h6" sx={{ mt: 2, mb: 2, color: "#FFFFFF" }}>
                 Price: {`${market.Price}`} TFUEL
               </Typography>
             )}


### PR DESCRIPTION
**Implemented:**
Show active buttons for NFTs that are owned by a wallet

![image](https://github.com/OCTOplace/octoplace-ui/assets/116144992/9a008a7c-0bf5-4684-a756-584de77ef6d7)

![image](https://github.com/OCTOplace/octoplace-ui/assets/116144992/1e8e6b4d-81b0-4dcf-b8ee-fed737cb74a3)
